### PR TITLE
CI - check if metrics is uploaded (#2)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,3 +26,7 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKENA }}

--- a/src/test_main.rs
+++ b/src/test_main.rs
@@ -1,6 +1,7 @@
 // We are going TDD now
 // or maybe not, the fact is, we are testing for behaviours - this way makes me feel more comfortable
 
+use crate::greet;
 
 // test the behaviour of our greet function from main.rs
 #[test]


### PR DESCRIPTION
I have tried quite a number of approaches to get `cargo` to run coverage report
ready for Codecov uploader - with insignificant progress.

As of 2017 - Rust Edition 1.7, rust does not support official collection of coverage metrics
from binaries nor is there external support for it that i know of by the community - that said,
all hands on deck, as i seek other solutions.

This ![post](https://stackoverflow.com/questions/69491669/how-i-can-get-coverage-for-cargo-test)
proposes a different approach to run codecov and I would be taking a look at it at a later date.
